### PR TITLE
F/support context alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "kubesess"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubesess"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["https://github.com/ramilito"]
 edition = "2021"
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,8 @@
 use crate::config;
 use crate::model::Config;
 use dialoguer::{theme::ColorfulTheme, FuzzySelect};
+use std::fs::File;
+use std::io::{BufReader, Read};
 use std::process::{Command, Stdio};
 
 pub fn set_default_namespace(ns: &str) {
@@ -35,13 +37,20 @@ pub fn set_default_context(ctx: &str) {
 }
 
 pub fn get_config() -> Config {
-    let output = Command::new("kubectl")
-        .args(["config", "view", "-o", "json"])
-        .output()
-        .unwrap();
+    let f = File::open(format!(
+        "{}/.kube/config",
+        dirs::home_dir().unwrap().display().to_string()
+    ))
+    .unwrap();
 
-    let string = String::from_utf8(output.stdout).unwrap();
-    let config: Config = serde_json::from_str(&string.trim()).unwrap();
+    let mut reader = BufReader::new(f);
+    let mut string = String::new();
+
+    reader
+        .read_to_string(&mut string)
+        .expect("Unable to read file");
+
+    let config: Config = serde_yaml::from_str(&string.trim()).unwrap();
 
     config
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::model::Config;
 use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 use std::process::{Command, Stdio};
 
@@ -33,14 +34,16 @@ pub fn set_default_context(ctx: &str) {
         .unwrap();
 }
 
-pub fn get_context() -> Vec<String> {
+pub fn get_config() -> Config {
     let output = Command::new("kubectl")
-        .args(["config", "get-contexts", "-o", "name"])
+        .args(["config", "view", "-o", "json"])
         .output()
         .unwrap();
 
     let string = String::from_utf8(output.stdout).unwrap();
-    string.lines().map(ToOwned::to_owned).collect()
+    let config: Config = serde_json::from_str(&string.trim()).unwrap();
+
+    config
 }
 
 pub fn get_namespaces() -> Vec<String> {
@@ -77,10 +80,13 @@ pub fn selectable_list(input: Vec<String>) -> String {
     input[selection].to_string()
 }
 
-pub fn set_namespace(ctx: &str, selection: &str, temp_dir: &str) {
-    config::set(ctx, Some(selection), temp_dir)
+pub fn set_namespace(ctx: &str, selection: &str, temp_dir: &str, config: &Config) {
+    let choice = config.contexts.iter().find(|x| x.name == ctx);
+    config::set(choice.unwrap(), Some(selection), temp_dir)
 }
 
-pub fn set_context(ctx: &str, temp_dir: &str) {
-    config::set(ctx, None, temp_dir)
+pub fn set_context(ctx: &str, temp_dir: &str, config: &Config) {
+    let choice = config.contexts.iter().find(|x| x.name == ctx);
+
+    config::set(choice.unwrap(), None, temp_dir);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,59 +1,31 @@
-use serde::{Deserialize, Serialize};
+use crate::model::{Config, Context, Contexts};
+
 use std::{
     fs::{self, File},
     io::{BufRead, BufReader, BufWriter},
     path::Path,
 };
 
-#[derive(Default, Debug, Serialize, Deserialize)]
-struct Contexts {
-    context: Context,
-    name: String,
-}
-
-#[derive(Default, Debug, Serialize, Deserialize)]
-struct Context {
-    namespace: String,
-    cluster: String,
-    user: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct Config {
-    #[serde(skip_serializing_if = "String::is_empty", default)]
-    kind: String,
-    #[serde(rename = "apiVersion")]
-    #[serde(skip_serializing_if = "String::is_empty", default)]
-    api_version: String,
-    #[serde(skip_serializing_if = "String::is_empty", default)]
-    #[serde(rename = "current-context")]
-    current_context: String,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    contexts: Vec<Contexts>,
-}
-
-fn build_config(ctx: &str, namespace: Option<&str>, strbuf: &str) -> Config {
+fn build_config(ctx: &Contexts, ns: Option<&str>, strbuf: &str) -> Config {
     let mut config: Config = serde_yaml::from_str(&strbuf).unwrap();
     config.api_version = "v1".to_string();
     config.kind = "Config".to_string();
-    config.current_context = format!("{}", ctx);
+    config.current_context = format!("{}", ctx.name);
 
-    if let Some(ns) = namespace {
-        config.contexts = vec![Contexts {
-            context: Context {
-                namespace: ns.to_string(),
-                cluster: ctx.to_string(),
-                user: ctx.to_string(),
-            },
-            name: ctx.to_string(),
-        }];
-    }
+    config.contexts = vec![Contexts {
+        context: Context {
+            namespace: ns.unwrap_or("default").to_string(),
+            cluster: ctx.context.cluster.to_string(),
+            user: ctx.context.user.to_string(),
+        },
+        name: ctx.name.to_string(),
+    }];
 
     config
 }
 
-fn get_config_file(ctx: &str, dest: &str) -> File {
-    let path = Path::new(ctx);
+fn get_config_file(ctx: &Contexts, dest: &str) -> File {
+    let path = Path::new(ctx.name.as_str());
     let parent = path.parent().unwrap();
     let dirname = str::replace(&parent.display().to_string(), ":", "_");
     let _ = fs::create_dir_all(format!("{}/{}", dest, dirname));
@@ -62,6 +34,7 @@ fn get_config_file(ctx: &str, dest: &str) -> File {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(format!(
             "{}/{}/{}",
             dest,
@@ -72,9 +45,9 @@ fn get_config_file(ctx: &str, dest: &str) -> File {
     f
 }
 
-pub fn set(ctx: &str, namespace: Option<&str>, dest: &str) {
+pub fn set(ctx: &Contexts, namespace: Option<&str>, dest: &str) {
     let strbuf = String::new();
-    let options = get_config_file(ctx, dest);
+    let options = get_config_file(&ctx, dest);
     let mut reader = BufReader::new(&options);
 
     reader
@@ -82,7 +55,7 @@ pub fn set(ctx: &str, namespace: Option<&str>, dest: &str) {
         .expect("Unable to read file");
 
     let writer = BufWriter::new(&options);
-    let config = build_config(ctx, namespace, strbuf.as_str());
+    let config = build_config(&ctx, namespace, strbuf.as_str());
 
     serde_yaml::to_writer(writer, &config).unwrap();
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,8 @@
 use crate::model::{Config, Context, Contexts};
 
-use std::{
-    fs::{self, File},
-    io::{BufRead, BufReader, BufWriter},
-    path::Path,
-};
+use std::fs::{self, File};
+use std::io::BufWriter;
+use std::path::Path;
 
 fn build_config(ctx: &Contexts, ns: Option<&str>, strbuf: &str) -> Config {
     let mut config: Config = serde_yaml::from_str(&strbuf).unwrap();
@@ -12,9 +10,19 @@ fn build_config(ctx: &Contexts, ns: Option<&str>, strbuf: &str) -> Config {
     config.kind = "Config".to_string();
     config.current_context = format!("{}", ctx.name);
 
+    let ns = if ns.is_some() {
+        ns.unwrap().to_string()
+    } else if config.contexts.len() > 0 && !config.contexts[0].context.namespace.is_empty() {
+        config.contexts[0].context.namespace.to_string()
+    } else if !ctx.context.namespace.is_empty() {
+        ctx.context.namespace.to_string()
+    } else {
+        "default".to_string()
+    };
+
     config.contexts = vec![Contexts {
         context: Context {
-            namespace: ns.unwrap_or("default").to_string(),
+            namespace: ns.to_string(),
             cluster: ctx.context.cluster.to_string(),
             user: ctx.context.user.to_string(),
         },
@@ -24,38 +32,39 @@ fn build_config(ctx: &Contexts, ns: Option<&str>, strbuf: &str) -> Config {
     config
 }
 
-fn get_config_file(ctx: &Contexts, dest: &str) -> File {
-    let path = Path::new(ctx.name.as_str());
-    let parent = path.parent().unwrap();
-    let dirname = str::replace(&parent.display().to_string(), ":", "_");
-    let _ = fs::create_dir_all(format!("{}/{}", dest, dirname));
-
+fn get_config_file(path: &String) -> File {
     let f = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(true)
-        .open(format!(
-            "{}/{}/{}",
-            dest,
-            dirname,
-            path.file_name().unwrap().to_string_lossy()
-        ))
+        .open(path)
         .expect("Unable to open file");
     f
 }
 
+fn get_path(ctx: &Contexts, dest: &str) -> String {
+    let path = Path::new(ctx.name.as_str());
+    let parent = path.parent().unwrap();
+    let dirname = str::replace(&parent.display().to_string(), ":", "_");
+
+    fs::create_dir_all(format!("{}/{}", dest, dirname)).expect("Could not create destination dir");
+
+    let path = Path::new(dest).join(&dirname).join(path.file_name().unwrap());
+    path.display().to_string()
+}
+
 pub fn set(ctx: &Contexts, namespace: Option<&str>, dest: &str) {
-    let strbuf = String::new();
-    let options = get_config_file(&ctx, dest);
-    let mut reader = BufReader::new(&options);
+    let path = get_path(ctx, dest);
 
-    reader
-        .read_line(&mut strbuf.to_string())
-        .expect("Unable to read file");
+   let strbuf = match fs::read_to_string(&path) {
+        Ok(file) => file,
+        Err(_error) => "".to_string(),
+    };
 
+    let options = get_config_file(&path);
     let writer = BufWriter::new(&options);
-    let config = build_config(&ctx, namespace, strbuf.as_str());
+    let config = build_config(&ctx, namespace, &strbuf);
 
     serde_yaml::to_writer(writer, &config).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod config;
 mod modes;
+mod model;
 
 use clap::Parser;
 use std::{env, io};

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct Contexts {
+    pub context: Context,
+    pub name: String,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct Context {
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub namespace: String,
+    pub cluster: String,
+    pub user: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub kind: String,
+    #[serde(rename = "apiVersion")]
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub api_version: String,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    #[serde(rename = "current-context")]
+    pub current_context: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub contexts: Vec<Contexts>,
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,12 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Contexts {
+    #[serde(default)]
     pub context: Context,
+    #[serde(default)]
     pub name: String,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Context {
     #[serde(skip_serializing_if = "String::is_empty", default)]
     pub namespace: String,
@@ -14,7 +16,7 @@ pub struct Context {
     pub user: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     #[serde(skip_serializing_if = "String::is_empty", default)]
     pub kind: String,
@@ -24,6 +26,6 @@ pub struct Config {
     #[serde(skip_serializing_if = "String::is_empty", default)]
     #[serde(rename = "current-context")]
     pub current_context: String,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub contexts: Vec<Contexts>,
 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -8,39 +8,59 @@ fn selection(value: Option<String>, callback: fn() -> String) -> String {
 }
 
 pub fn default_context(args: Cli, dest: &str) {
-    let ctx = selection(args.value, || -> String {
-        let contexts = commands::get_context();
-        commands::selectable_list(contexts)
-    });
+    let config = commands::get_config();
+
+    let ctx = match args.value {
+        None => {
+            let mut options = Vec::new();
+            for context in &config.contexts {
+                options.push(context.name.to_string());
+            }
+
+            commands::selectable_list(options)
+        }
+        Some(x) => x.trim().to_string(),
+    };
 
     commands::set_default_context(&ctx);
-    commands::set_context(&ctx, &dest);
+    commands::set_context(&ctx, &dest, &config);
 }
 
 pub fn context(args: Cli, dest: &str) {
-    let ctx = selection(args.value, || -> String {
-        let contexts = commands::get_context();
-        commands::selectable_list(contexts)
-    });
+    let config = commands::get_config();
 
-    commands::set_context(&ctx, &dest);
+    let ctx = match args.value {
+        None => {
+            let mut options = Vec::new();
+            for context in &config.contexts {
+                options.push(context.name.to_string());
+            }
+
+            commands::selectable_list(options)
+        }
+        Some(x) => x.trim().to_string(),
+    };
+
+    commands::set_context(&ctx, &dest, &config);
 
     println!("{}/{}", &dest, str::replace(&ctx, ":", "_"));
 }
 
 pub fn namespace(args: Cli, dest: &str) {
+    let config = commands::get_config();
     let ctx = commands::get_current_context();
     let ns = selection(args.value, || -> String {
         let namespaces = commands::get_namespaces();
         commands::selectable_list(namespaces)
     });
 
-    commands::set_namespace(&ctx, &ns, &dest);
+    commands::set_namespace(&ctx, &ns, &dest, &config);
 
     println!("{}/{}", &dest, str::replace(&ctx, ":", "_"));
 }
 
 pub fn default_namespace(args: Cli, dest: &str) {
+    let config = commands::get_config();
     let ctx = commands::get_current_context();
     let ns = selection(args.value, || -> String {
         let namespaces = commands::get_namespaces();
@@ -48,5 +68,5 @@ pub fn default_namespace(args: Cli, dest: &str) {
     });
 
     commands::set_default_namespace(&ns);
-    commands::set_namespace(&ctx, &ns, &dest);
+    commands::set_namespace(&ctx, &ns, &dest, &config);
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Lots of changes were needed to allow for aliases to be used.
First, we needed to use more than the name to set all the props, so replacing:
```.args(["config", "get-contexts", "-o", "name"])
```
Not using jsonpath for performance reasons and went straight for the file, bypassing kubectl completely

Fixed some more issues along the way that were caused by this PR, namespace not being saved properly.

Fixes # (issue)
#11 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
 
Manually....2 am....

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
