### PR TITLE
Fix knd on Fish

### DIFF
--- a/scripts/fish/functions/knd.fish
+++ b/scripts/fish/functions/knd.fish
@@ -1,3 +1,3 @@
-function kcd --argument-names namespace --description "Switch global kubernetes namespace"
+function knd --argument-names namespace --description "Switch global kubernetes namespace"
     kubesess -v $namespace default-namespace
 end


### PR DESCRIPTION
Instead of declaring the `knd` function on Fish, the package overrides `kcd` with the implementation for `knd`.