### PR TITLE
Fix Fish functions

### DIFF
--- a/scripts/fish/functions/kc.fish
+++ b/scripts/fish/functions/kc.fish
@@ -1,4 +1,8 @@
 function kc --argument-names context --description "Switch current kubernetes context"
-    set -l config (kubesess -v $context context) 
+    set -l cmd kubesess context
+    if test -n "$argv"
+        set -a cmd -v $context
+    end
+    set -l config (command $cmd) || return $status
     set -gx KUBECONFIG $config
 end

--- a/scripts/fish/functions/kcd.fish
+++ b/scripts/fish/functions/kcd.fish
@@ -1,4 +1,8 @@
 function kcd --argument-names context --description "Switch global kubernetes context"
-    set -l config (kubesess -v $context default-context) 
+    set -l cmd kubesess default-context
+    if test -n "$argv"
+        set -a cmd -v $context
+    end
+    set -l config (command $cmd) || return $status
     set -gx KUBECONFIG $config
 end

--- a/scripts/fish/functions/kn.fish
+++ b/scripts/fish/functions/kn.fish
@@ -1,4 +1,8 @@
 function kn --argument-names namespace --description "Switch current kubernetes namespace"
-    set -l config (kubesess -v $namespace namespace) 
+    set -l cmd kubesess namespace
+    if test -n "$argv"
+        set -a cmd -v $namespace
+    end
+    set -l config (command $cmd) || return $status
     set -gx KUBECONFIG $config
 end

--- a/scripts/fish/functions/knd.fish
+++ b/scripts/fish/functions/knd.fish
@@ -1,3 +1,7 @@
-function knd --argument-names namespace --description "Switch global kubernetes namespace"
-    kubesess -v $namespace default-namespace
+function kcd --argument-names context --description "Switch global kubernetes context"
+    set -l cmd kubesess default-context
+    if test -n "$argv"
+        set -a cmd -v $context
+    end
+    command $cmd
 end


### PR DESCRIPTION
There are two issues with the current implementation of the Fish functions:
1. If called without an argument, unlike the Bash ones, they don't prompt to choose a value from the list.
2. They don't handle the error from the underlying `kubesess` process, so they erase `$KUBECONFIG` in case of an error.

**How to reproduce**:
```shell
# Choose a namespace
→ kn strimzi

# Make sure that `$KUBECONFIG` is set
→ echo $KUBECONFIG
/Users/smorozov/.kube/kubesess/cache/redacted:/Users/smorozov/.kube/config

# Try to call without an argument
→ kn
error: The following required arguments were not provided:
    <MODE>

USAGE:
    kubesess --value <VALUE> <MODE>

For more information try --help

# Check `$KUBECONFIG`
→ echo $KUBECONFIG
# It's empty
```

This patch brings parity between the Bash and Fish functions:
1. If an argument is not passed to a function, it's not passed as a `-v` to `kubesess`.
2. If `kubesess` exits with a non-zero status, the config remains unchanged.