### PR TITLE
Fix knd implementation for Fish

### DIFF
--- a/scripts/fish/functions/knd.fish
+++ b/scripts/fish/functions/knd.fish
@@ -1,5 +1,5 @@
-function kcd --argument-names context --description "Switch global kubernetes context"
-    set -l cmd kubesess default-context
+function knd --argument-names context --description "Switch global kubernetes namespace"
+    set -l cmd kubesess default-namespace
     if test -n "$argv"
         set -a cmd -v $context
     end


### PR DESCRIPTION
The `knd` function declared in `knd.fish` got accidentally renamed to `kcd` in #41. This patch reverts that.