### PR TITLE
Handle exit codes in shell wrapper

### DIFF
--- a/scripts/sh/kubesess.sh
+++ b/scripts/sh/kubesess.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 
+__kubesess_export() {
+  local OUTPUT
+  OUTPUT="$(kubesess "$@")" || return $?
+  export KUBECONFIG="$OUTPUT"
+}
+
 kc() {
-  export KUBECONFIG=$(kubesess ${1:+"-v "$1} context);
+  __kubesess_export ${1:+"-v "$1} context
 }
 
 kcd() {
-  export KUBECONFIG=$(kubesess ${1:+"-v "$1} default-context);
+  __kubesess_export ${1:+"-v "$1} default-context
 }
 
 kn() {
-  export KUBECONFIG=$(kubesess ${1:+"-v "$1} namespace);
+  __kubesess_export ${1:+"-v "$1} namespace
 }
 
 knd() {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::model::Config;
-use crate::{config, ORIGINALKUBECONFIG};
+use crate::config;
 
 use std::process;
 use std::{
@@ -79,7 +79,7 @@ pub fn selectable_list(input: Vec<String>) -> String {
         .unwrap_or_default();
 
     if selected_items.is_empty() {
-        println!("{}", ORIGINALKUBECONFIG.to_string());
+        eprintln!("No item selected");
         process::exit(1);
     }
 


### PR DESCRIPTION
Fixes #47.

All sub-commands have been tested with the scenario from https://github.com/Ramilito/kubesess/issues/43#issuecomment-1299349931 on Bash and Fish:
```shell
→ kc
# Press ESC
No item selected

→ kcd
# Press ESC
No item selected

→ kn
# Press ESC
No item selected

→ knd
# Press ESC
No item selected
```