### PR TITLE
Handle and print error instead of panic when passing nonexistent context

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::model::KubeConfig;
 use crate::config;
 
+use core::fmt;
 use std::process;
 use std::{
     io::Cursor,
@@ -91,7 +92,26 @@ pub fn set_namespace(ctx: &str, selection: &str, temp_dir: &str, config: &KubeCo
     config::write(choice.unwrap(), Some(selection), temp_dir)
 }
 
-pub fn set_context(ctx: &str, temp_dir: &str, config: &KubeConfig) {
-    let choice = config.contexts.iter().find(|x| x.name == ctx);
-    config::write(choice.unwrap(), None, temp_dir);
+pub fn set_context(ctx: &str, temp_dir: &str, config: &KubeConfig) -> Result<(), SetContextError> {
+    if let Some(choice) = config.contexts.iter().find(|x| x.name == ctx) {
+        config::write(choice, None, temp_dir);
+        Ok(())
+    } else {
+        Err(SetContextError::ContextNotFound{ctx: ctx.to_owned()})
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SetContextError {
+    ContextNotFound {
+        ctx : String
+    },
+}
+
+impl fmt::Display for SetContextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SetContextError::ContextNotFound{ctx} => write!(f, "couldn't find context {}", ctx),
+        }
+    }
 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -1,4 +1,6 @@
-use crate::{commands, config, Cli, DEST, KUBECONFIG};
+use std::process;
+
+use crate::{commands::{self}, config, Cli, DEST, KUBECONFIG};
 
 fn selection(value: Option<String>, callback: fn() -> String) -> String {
     match value {
@@ -28,9 +30,13 @@ pub fn default_context(args: Cli) {
     };
 
     commands::set_default_context(&ctx);
-    commands::set_context(&ctx, &DEST, &config);
-
-    println!("{}", KUBECONFIG.as_str());
+    match commands::set_context(&ctx, &DEST, &config) {
+        Ok(()) => println!("{}", KUBECONFIG.as_str()),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    }
 }
 
 pub fn context(args: Cli) {
@@ -53,14 +59,20 @@ pub fn context(args: Cli) {
         Some(x) => x.trim().to_string(),
     };
 
-    commands::set_context(&ctx, &DEST, &config);
-
-    println!(
-        "{}/{}:{}",
-        &DEST.as_str(),
-        str::replace(&ctx, ":", "_"),
-        KUBECONFIG.to_string()
-    );
+    match commands::set_context(&ctx, &DEST, &config) {
+        Ok(()) => {
+            println!(
+                "{}/{}:{}",
+                &DEST.as_str(),
+                str::replace(&ctx, ":", "_"),
+                KUBECONFIG.to_string()
+            );
+        },
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    }
 }
 
 pub fn namespace(args: Cli) {


### PR DESCRIPTION
# Description

Currently, when trying to pass a context that does not exist in the configured `KUBECONFIG`, e.g `kc foo` or `kubesess context -v foo`, the program panics:

```bash
❯ kubesess context -v foo
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/commands.rs:96:19
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This doesn't tell the user what went wrong and makes what is a just user error look like a bug.

To fix this, `set_context` now returns a `Result<(), SetContextError>`, which is appropriately handled. If there is an error, the program will exit with a non-zero exit code and report the error on stderr (similarly to the error handling in `commands::selectable_list`).

Fixed behaviour:

```bash
❯ kc foo
Error: Couldn't find context foo
```

## Implementation hints / Considerations

- I used an enum with a single case as the error type to make it extensible. If you'd prefer, a struct could be used instead. Overall, it doesn't really make a big difference.
- A dedicated error crate like `thiserror` could make the error implementation more terse, but that adds another depedency that is not needed at this point. It's only 12 lines as is.

Looking forward to your feedback :)
*Also thanks for creating kubesess, I use it everyday and it makes my life easier, particularly with direnv it's a charm*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- End-to-end test using `kubesess` and the provided shell scripts
- Not tested using the fish scripts

**Test Configuration**:
* Firmware version (does not make sense to me, listing kernel): `Linux 6.6.4-arch1-1`
* Hardware: `Intel i7-1260P`
* Toolchain: `stable-x86_64-unknown-linux-gnu`
* SDK: `rustc 1.70.0`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
