### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,7 @@ pub fn set_default_namespace(ns: &str, ctx: &str) {
         .arg("config")
         .arg(format!(
             "--kubeconfig={}/.kube/config",
-            dirs::home_dir().unwrap().display().to_string()
+            dirs::home_dir().unwrap().display()
         ))
         .arg("set-context")
         .arg(ctx)
@@ -32,7 +32,7 @@ pub fn set_default_context(ctx: &str) {
         .arg("config")
         .arg(format!(
             "--kubeconfig={}/.kube/config",
-            dirs::home_dir().unwrap().display().to_string()
+            dirs::home_dir().unwrap().display()
         ))
         .arg("use-context")
         .arg(ctx)

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ lazy_static! {
         match env::var("KUBECONFIG") {
             Ok(val) => {
                 let mut paths: String = String::new();
-                for s in val.split_inclusive(":") {
+                for s in val.split_inclusive(':') {
                     if s.contains("/kubesess/cache") {
                         continue;
                     }
@@ -30,7 +30,7 @@ lazy_static! {
         match env::var("KUBECONFIG") {
             Ok(val) => {
                 let mut paths: String = String::new();
-                for s in val.split(":") {
+                for s in val.split(':') {
                     if s.contains("/kubesess/cache") {
                         paths.push_str(s);
                     }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -65,7 +65,7 @@ pub fn context(args: Cli) {
                 "{}/{}:{}",
                 &DEST.as_str(),
                 str::replace(&ctx, ":", "_"),
-                KUBECONFIG.to_string()
+                *KUBECONFIG
             );
         },
         Err(e) => {
@@ -107,7 +107,7 @@ pub fn namespace(args: Cli) {
         "{}/{}:{}",
         &DEST.as_str(),
         str::replace(&config.current_context, ":", "_"),
-        KUBECONFIG.to_string()
+        *KUBECONFIG
     );
 }
 


### PR DESCRIPTION
# Description

Hi Ramilito,

nothing big this time, just used  `cargo clippy` to check the code base for linter warnings.
Mostly small changes like superfluous dereferences or excessive `.to_string()`.
The biggest change worth looking at would be the rewrite of the pattern matching in `config.rs` line 13 to avoid the unwrap().
We could also add a Github Action to automatically run cargo clippy on PRs to ensure code quality, what do you think?
For example <https://github.com/giraffate/clippy-action>, maintained by a member of the rust-lang clippy team.
We could add it in this PR or a separate one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No specific tests, just fixes linter warnings

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
