### PR TITLE
Readd linux gnu builds, fix installation instructions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -92,7 +92,7 @@ Probably most of the speed gains are because I am bypassing kubectl and just edi
 #### Binary
 Download and extract the binary.
 ```zsh
-KUBESESS_VERSION=1.2.10 && \
+KUBESESS_VERSION=1.2.11 && \
 KUBESESS_OS=x86_64-unknown-linux-gnu && \
 wget "https://github.com/Ramilito/kubesess/releases/download/${KUBESESS_VERSION}/kubesess_${KUBESESS_VERSION}_${KUBESESS_OS}.tar.gz" && \
 mkdir -p $HOME/.kube/kubesess && tar zxpf kubesess_${KUBESESS_VERSION}_${KUBESESS_OS}.tar.gz -C $HOME/.kube/kubesess && \

--- a/.github/workflows/package_and_release.yaml
+++ b/.github/workflows/package_and_release.yaml
@@ -18,28 +18,25 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        build: [linux, macos, macos-arm]
         include:
-        - build: linux
-          os: ubuntu-22.04
+        - os: ubuntu-22.04
+          rust: stable
+          target: x86_64-unknown-linux-gnu
+        - os: ubuntu-22.04
+          rust: stable
+          target: aarch64-unknown-linux-gnu
+        - os: ubuntu-22.04
           rust: stable
           target: x86_64-unknown-linux-musl
-          name: x86_64-linux
-        - build: linux-arm
-          os: ubuntu-22.04
+        - os: ubuntu-22.04
           rust: stable
           target: aarch64-unknown-linux-musl
-          name: aarch64-linux
-        - build: macos
-          os: macos-12
+        - os: macos-12
           rust: stable
           target: x86_64-apple-darwin
-          name: x86_64-macos
-        - build: macos-arm
-          os: macos-12
+        - os: macos-12
           rust: stable
           target: aarch64-apple-darwin
-          name: aarch64-macos
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "kubesess"
-version = "1.2.9"
+version = "1.2.11"
 dependencies = [
  "assert_cmd",
  "clap 3.2.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubesess"
-version = "1.2.10"
+version = "1.2.11"
 authors = ["https://github.com/ramilito"]
 edition = "2021"
 


### PR DESCRIPTION
# Description

- https://github.com/Ramilito/kubesess/commit/e4ac9e3ba6ebe705a0a73b18da3242ccb3b87db9 removed builds for glibc / gnu linux, providing only musl libc artifacts. I think it's very convenient to users to provide gnu binaries - it's probably still the most widely used libc - so this PR adds them back, while also keeping the musl builds.
- The installation instructions are currently broken: README.md even still refers to the removed gnu artifact and to an outdated version
- The crate version in Cargo.toml was also outdated
- The `name` and `build` matrix variables of the build matrix were unused and just an abbreviation of the `target` variable

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not tested

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
