### PR TITLE
[Fix] - Kubeconfig merge needs user and cluster

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -89,12 +89,12 @@ pub fn selectable_list(input: Vec<String>) -> String {
 
 pub fn set_namespace(ctx: &str, selection: &str, temp_dir: &str, config: &KubeConfig) {
     let choice = config.contexts.iter().find(|x| x.name == ctx);
-    config::write(choice.unwrap(), Some(selection), temp_dir)
+    config::write(choice.unwrap(), config, Some(selection), temp_dir)
 }
 
 pub fn set_context(ctx: &str, temp_dir: &str, config: &KubeConfig) -> Result<(), SetContextError> {
     if let Some(choice) = config.contexts.iter().find(|x| x.name == ctx) {
-        config::write(choice, None, temp_dir);
+        config::write(choice, config, None, temp_dir);
         Ok(())
     } else {
         Err(SetContextError::ContextNotFound{ctx: ctx.to_owned()})

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,21 +32,20 @@ fn build(ctx: &Contexts, kube_config: &KubeConfig, ns: Option<&str>, strbuf: &st
         name: ctx.name.to_string(),
     }];
 
-    if let Some(u) = kube_config.users.iter().find(|x| x.name == ctx.context.user) {
-        let usr = u.clone();
+    if let Some(user) = kube_config.users.iter().find(|x| x.name == ctx.context.user) {
         config.users = vec![Users {
-            name: usr.name,
-            user: usr.user,
+            name: user.name.clone(),
+            user: user.user.clone(),
         }];
     }
 
-    if let Some(c) = kube_config.clusters.iter().find(|x| x.name == ctx.context.cluster) {
-        let cluster = c.clone();
+    if let Some(cluster) = kube_config.clusters.iter().find(|x| x.name == ctx.context.cluster) {
         config.clusters = vec![Clusters {
-            name: cluster.name,
-            cluster: cluster.cluster,
+            name: cluster.name.clone(),
+            cluster: cluster.cluster.clone(),
         }];
     }
+
     config
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 
 #[derive(Default, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Contexts {
@@ -6,6 +9,38 @@ pub struct Contexts {
     pub context: Context,
     #[serde(default)]
     pub name: String,
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Clusters {
+    #[serde(default)]
+    pub cluster: Cluster,
+    #[serde(default)]
+    pub name: String,
+}
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Cluster {
+    #[serde(rename = "certificate-authority-data")]
+    pub certificate_authority_data: String,
+    pub server: String,
+}
+
+#[derive(Default, Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct Users {
+    #[serde(default)]
+    pub user: HashMap<String, Value>,
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Default, PartialEq, Debug, Serialize, Deserialize)]
+pub struct User {
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    #[serde(rename = "client-certificate-data")]
+    pub client_certificate_data: String,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    #[serde(rename = "client-key-data")]
+    pub client_key_data: String,
 }
 
 #[derive(Default, PartialEq, Debug, Serialize, Deserialize)]
@@ -28,4 +63,8 @@ pub struct KubeConfig {
     pub current_context: String,
     #[serde(default)]
     pub contexts: Vec<Contexts>,
+    #[serde(default)]
+    pub users: Vec<Users>,
+    #[serde(default)]
+    pub clusters: Vec<Clusters>,
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
When merging and not using kubeconfig env variable, the resulting cached files don't have cluster and user in them.
This PR adds those so they can be more complete.
Results:
![default](https://github.com/Ramilito/kubesess/assets/8473233/48867205-8e03-4137-b404-222b87ca6bc6)



Fixes # (issue)
#46 Fixes part of this


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally by using it for a while